### PR TITLE
Session 10: The Weaver's Die (Fate-themed)

### DIFF
--- a/ideas/the_weavers_die.md
+++ b/ideas/the_weavers_die.md
@@ -1,0 +1,68 @@
+---
+tags: [arena, encounter-idea, fate, dice-mechanic, mythological]
+encounter_type: combat
+party_size: "3-4"
+level_range: "5-6"
+difficulty: hard
+mechanics: [crowds-favor, panache, fate-die]
+status: ready
+created: 2026-05-20
+updated: 2026-05-20
+---
+
+# The Weaver's Die
+
+## Hook
+Three strangers wearing the same face — an albino Tiefling woman with tall horns and round glasses, but as a child (10), a woman (20), and a crone (70) — walk onto the sand before the bout. They are the **Three Fates**. Each presses a **Fate Die** into a gladiator's palm and promises, smiling, that "we always take back what we lend." The crowd thinks it's theater. It isn't.
+
+The die lets a player cheat fate — once. But every cheat is recorded, and the Crone plays the spent numbers back against the party. The whole encounter is a slow tightening noose: the more you bend luck, the more luck bends back.
+
+## Core Mechanic: The Fate Die
+See [[fate_die|Fate Die]] for full rules. In brief:
+- **Reaction**, after seeing the result of *any* d20 roll: roll a **d8** and add or subtract it from that raw result.
+- Going **over 20** wraps to 0; going **under 1** wraps to 20.
+- Every value spent is **dropped into the Hourglass Heart** (see below). The Crone uses those exact numbers against the party later.
+
+## Arena Layout
+- **The Tapestry Floor** — 60 x 60 ft of sand woven like cloth, each panel depicting a possible death of one of the gladiators. When a PC spends a Fate Die, the panel beneath them *unravels* into a 10 ft square of difficult terrain. By late fight the floor is scarred with everyone's cheating. (Drop a token where each die is spent — that's the only tracking.)
+- **The Hourglass Heart** — a giant black-sand hourglass center-stage. Every Fate Die used (by anyone) drops one chunk of sand. **Write the spent number on each chunk** — the chunks ARE the ledger. When the hourglass empties, the Crone takes a turn and replays those numbers (see Enemies).
+- **The Three Looms** — at the arena's edge, one per Fate; thread-walls slowly extend across the floor as cover/tripwires. Optional flavor, cut if it's too much.
+
+## Time Pressure
+- The Hourglass empties after **N Fate Dice are spent** (suggest 6 for 3 PCs). Greed accelerates doom.
+- **Crowd's Favor as the only brake:** a *spectacular* Fate Die use (clutch save, dramatic reversal) lets the crowd roar — pull one chunk back out and gain [[crowds_favor|Favor]]. Showmanship buys time; greed spends it.
+
+## Enemies (warmup → reveal)
+The opening trio mirrors the three Fates' actions — **spin, weave, measure** — leaving *cut* (Crone) and *unravel* (the Unwoven) for the back half.
+
+- **The Spinners** (3–4 skirmishers) — Moirai/Norn spinning motif; whirl weighted spindle-stones on cords. Low HP, numerous. Job: generate lots of PC rolls → tempt Fate Die use. Reflavor cultist/guard.
+- **The Loom-Warden** (controller centerpiece) — the Valkyrie war-loom of *Darraðarljóð* (weighted with skulls, shuttled with an arrow). Each turn casts a thread-line across the floor: Dex/Str save vs. restraint. *This is the temptation engine* — the failed save players desperately want to flip. Reflavor a CR 2–3 caster with web/entangle.
+- **The Measurer** (telegraph) — Lachesis with the measuring-rod / Norn rune-casting. Once per turn "takes the measure" of a PC and marks them; foreshadows the turnabout with zero tracking.
+
+### Back-half threats
+- **The Unwoven** — a fate-less horror outside the tapestry. **Fate Dice cannot affect any roll involving it.** Deploy it when the party leans hard on the dice: the Crone snips a thread, the crutch vanishes, one honest fight. Also a pacing valve. Reflavor a flesh golem / gloom.
+- **The Crone's Hand** (climax) — the turnabout made flesh. Doesn't roll normally: she **plays the spent numbers off the Hourglass against the party** as her own attack/save results. Optional single **Echo** (a thread-spun copy of the PC who burned the most dice; same AC, half HP, one attack/turn using the top number off the Hourglass; unravels at 0 HP or if its target spends a turn refusing to fight it).
+
+## The Choice (climax beat)
+To break the cycle, someone must **refuse to use a Fate Die** at a critical moment — or sacrifice a banked advantage — denying the Crone her ammunition.
+
+## Crowd's Favor Hooks
+- Spectacular Fate Die reversal (clutch save / turning a miss to a crit): pull a chunk from the Hourglass + [[crowds_favor|Favor]].
+- Refusing the die when it would obviously save you, and surviving anyway: +2 Favor (the crowd loves defiance of the gods).
+- [[panache|Panache]] kill on a Spinner with a wrapped-around die result (e.g., a "1" that became a "20"): +1 Favor.
+- Destroying a Loom dramatically: Panache roll.
+
+## Announcer Beats
+- Gift scene: "The gods themselves descend — and they come bearing GIFTS! What could go wrong?!"
+- First die spent: the Maiden giggles; a tapestry panel unravels underfoot. Nobody knows why yet.
+- Hourglass empties: "The sand runs OUT! And now — the Crone collects her DEBT!"
+- Unwoven enters: "Something the threads cannot touch! No luck saves you here, gladiators!"
+
+## Scaling
+- **3 PCs (level 5):** 3 Spinners, 1 Loom-Warden, 1 Measurer; Hourglass empties at 6 dice; Crone's Hand + 1 Echo.
+- **4 PCs:** 4 Spinners, add a second Measurer or bump Loom-Warden HP; Hourglass at 8 dice.
+
+## Aftermath Seeds
+- The Crone offers a returning gladiator a "better die" — a hook, a trap, or both.
+- A spent Fate Die left on the sand becomes a coveted/cursed relic; shady seers bid on it.
+- A PC who *refused* the die at the climax earns a Fate's quiet respect (a future boon, or a future debt).

--- a/mechanics/fate_die.md
+++ b/mechanics/fate_die.md
@@ -1,0 +1,47 @@
+---
+tags: [arena, mechanics, homebrew, fate, event]
+mechanic_type: event
+complexity: moderate
+status: active
+visibility: private
+created: 2026-05-20
+updated: 2026-05-20
+aliases: [fate die, fate-die, the weavers die]
+---
+
+# Fate Die
+
+A special **event mechanic** for the [[the_weavers_die|The Weaver's Die]] session. The Three Fates lend each gladiator a die that lets them cheat fate — but every cheat is recorded and used back against them.
+
+## The Gift
+Each of the Three Fates (Maiden, Weaver, Crone) hands **one Fate Die (a d8)** to one gladiator. With 3 PCs, that's one die per player. The die is single-use unless reclaimed and re-gifted by a Fate.
+
+## Using a Fate Die
+
+**Trigger:** As a **reaction**, immediately after seeing the **raw result** of *any* d20 roll (yours or another creature's — attack, save, check, even an enemy's).
+
+**Effect:** Roll the d8 and **add or subtract** the result from that **raw d20 result** (before other modifiers). You choose add or subtract after rolling the d8.
+
+**Wrap-around:**
+- A modified result **over 20** wraps back to **0** (then keep counting up if the die is large — e.g., 19 + 5 = 24 → 4).
+- A modified result **under 1** wraps to **20** (e.g., 3 − 5 = −2 → 18).
+
+> The wrap is the gamble. A "safe" +3 on a 19 doesn't push to 22 — it crashes to 2.
+
+## The Debt: How the DM Uses It Back
+Every value a player **spends** (the final modified number, 1–20) is **dropped into the Hourglass Heart** — write it on a sand-chunk token. The Crone banks these numbers and **replays them as her own d20 results** later in the encounter (attack rolls, save DCs the party rolls against, the Echo's attacks). The party's cleverest saves become the blades at their throats.
+
+**Tracking need:** One token per spent die, marked with the final number. The tokens *are* the ledger — no separate sheet.
+
+## Interactions
+- **The Hourglass Heart:** each die used drops one chunk; when the hourglass empties (suggested 6 chunks for 3 PCs), the Crone acts. See [[the_weavers_die|The Weaver's Die]].
+- **The Tapestry Floor:** the panel beneath a die's user unravels into a 10 ft square of difficult terrain.
+- **The Unwoven:** Fate Dice **cannot** affect any roll involving the Unwoven. The crutch is gone.
+- **[[crowds_favor|Crowd's Favor]]:** a *spectacular* die use (clutch save, wrapping a 1 into a 20, turning a miss into a crit) lets the crowd roar — pull one chunk back out of the Hourglass and gain +1 Favor.
+- **[[panache|Panache]]:** a Panache roll produces a single chosen d20 result; a Fate Die can modify that result like any other.
+
+## Edge Cases
+- **Whose roll?** You can spend your die on *any* d20 you witness, including an enemy's attack against an ally — flip their hit into a miss. That number still goes in the Hourglass.
+- **Crit math:** a natural 20 turned to a 19 (e.g., −1) is no longer a crit; a 19 turned to 20 *is*. Use the modified number for crit/fumble determination.
+- **Reactions per round:** standard one-reaction limit. A player can spend at most one Fate Die per round unless a Fate grants more.
+- **Refusing the die:** at the climax, deliberately *not* spending a die (denying the Crone ammunition) is the intended escape and a major Favor reward.

--- a/sessions/session_10/.pages
+++ b/sessions/session_10/.pages
@@ -1,0 +1,3 @@
+title: "S10: The Weaver's Die"
+nav:
+  - index.md

--- a/sessions/session_10/index.md
+++ b/sessions/session_10/index.md
@@ -1,0 +1,41 @@
+---
+tags: [arena, session, session-10, index]
+session_number: 10
+party_level: 5
+status: planned
+visibility: private
+created: 2026-05-20
+updated: 2026-05-20
+---
+
+# Session 10: The Weaver's Die
+
+The Three Fates walk onto the sand wearing one face at three ages, and press a **Fate Die** into each gladiator's palm — a gift that lets them cheat fate once, with a smile and a promise: *"we always take back what we lend."* Cheat luck and luck cheats back. The Hourglass Heart fills with every spent die, and when it empties, the Crone collects her debt.
+
+**Party Level:** 3 PCs, Level 5
+**Difficulty:** Hard (escalating, self-inflicted)
+**Theme:** Fate, the cost of cheating luck, mythology of spinning/weaving/measuring
+**Expected Duration:** 8–10 rounds, 3 hours
+
+---
+
+## Session Files
+
+### For the GM
+- [[session_10_setup_gm|GM Setup & Preparation]]
+- [[session_10_encounter|Detailed Encounter Document]]
+- [[session_10_notes|Session Notes Template]]
+
+### For the Players
+- [[session_10_setup_players|Player Briefing & Setup]]
+- [[session_10_fate_die_card|🎲 Fate Die Player Card]] (half-page handout)
+
+---
+
+## Key Features
+- **[[fate_die|Fate Die]]** — d8 reaction die; add/subtract from any d20 raw result, wrapping over 20 → 0 and under 1 → 20. Every spent value is banked and used back against the party.
+- **The Hourglass Heart** — every die spent drops a numbered sand-chunk; empties at 6 chunks (3 PCs), triggering the Crone.
+- **The Tapestry Floor** — panels unravel into difficult terrain where dice are spent.
+- **Enemy arc** — Spinners → Loom-Warden → Measurer (spin/weave/measure), then the **Unwoven** (fate-proof) and the **Crone's Hand** (turnabout) + optional Echo.
+
+**Source:** [[the_weavers_die|/ideas/the_weavers_die.md]]

--- a/sessions/session_10/session_10_encounter.md
+++ b/sessions/session_10/session_10_encounter.md
@@ -1,0 +1,193 @@
+---
+tags: [arena, encounter, session-10]
+session_number: 10
+party_level: 5
+difficulty: hard
+status: planned
+visibility: private
+created: 2026-05-20
+updated: 2026-05-20
+---
+
+# Session 10 Encounter: The Weaver's Die
+
+## The Weaver's Die
+
+**Party:** 3 PCs, Level 5 (from the active roster — [[imwe|Imwe]], [[torgana|Torgana]], [[father_crow|Father Crow]], [[killing_eagle_laughs|Killing Eagle Laughs]])
+**Objective:** Survive the Fates' game. Break the cycle by denying the Crone the luck you spent.
+
+---
+
+## Arena Layout
+
+A 60 x 60 ft floor of sand woven like a vast tapestry, every panel depicting a possible death of one of the gladiators. Center stage stands the **Hourglass Heart** — a man-tall hourglass of black sand. At three edges sit the **Three Looms**, one per Fate, who knit calmly throughout.
+
+### Key Features
+- **The Tapestry Floor** — woven death-scenes underfoot.
+- **The Hourglass Heart** — the doom clock and the ledger in one object (center, can be moved around but not destroyed; it is not of this world).
+- **Three Looms** — edge features; optionally extend thread-walls as cover/tripwires.
+
+### Environmental Rules
+- **Tapestry unravel:** when a PC spends a [[fate_die|Fate Die]], the 10 ft square beneath them unravels into **difficult terrain** for the rest of the encounter. Drop a token.
+- **Hourglass fill:** every Fate Die used (by anyone) drops one **numbered sand-chunk** into the Hourglass. At **6 chunks** (3 PCs), the Hourglass empties and the **Crone's Hand** acts (see below).
+- **Crowd brake:** a *spectacular* die use lets the crowd roar — pull one chunk back out and gain +1 [[crowds_favor|Favor]].
+
+---
+
+## Special Mechanic: The Fate Die
+Full rules in [[fate_die|Fate Die]]. Summary for the table:
+- **Reaction**, after seeing any d20's **raw result**: roll a **d8**, add or subtract from that result.
+- Over 20 wraps to 0; under 1 wraps to 20.
+- The final number is **banked in the Hourglass** and replayed against the party by the Crone.
+
+---
+
+## Enemies
+
+The opening trio mirrors the three Fates' actions — **spin, weave, measure**. *Cut* (the Crone) and *unravel* (the Unwoven) are held for the back half.
+
+### Composition
+
+**The Spinners (×3) — skirmishers**
+Whirl weighted spindle-stones on cords. Reflavor **Cultist / Tribal Warrior**.
+- AC 13, HP 22, Speed 30 ft.
+- Multiattack option: 2× spindle-sling, +4 to hit, range 30 ft, 1d6+2 bludgeoning.
+- *Drawing Thread:* on a hit, the target's next d20 this round can be forced to reroll by a Spinner (drains the temptation to "fix" it with a die). Use sparingly.
+- **Role:** generate volume of rolls → tempt Fate Die use. Die fast.
+
+**The Loom-Warden (×1) — controller centerpiece**
+The Valkyrie war-loom of *Darraðarljóð*: skull-weighted, shuttled with an arrow. Reflavor **Mage / Sea Hag** with web.
+- AC 14, HP 75, Speed 20 ft.
+- *Shuttle Pass (recharge 4–6):* casts a thread-line in a 30 ft line; each creature in it makes a **DC 14 Dex save** or be **Restrained** (escape DC 14 Str/Dex). **This is the temptation engine** — the save players will itch to flip.
+- *Skull-Weight:* melee +5, 2d6+3 bludgeoning, knocks prone on a failed DC 13 Str save.
+- **Role:** the centerpiece of the warmup; its restraint saves should fill the Hourglass.
+
+**The Measurer (×1) — telegraph**
+Lachesis with the measuring-rod / Norn rune-casting. Reflavor **Acolyte / Cult Fanatic**, low threat.
+- AC 12, HP 40, Speed 30 ft.
+- *Take the Measure (1/turn, no attack):* marks a PC within 60 ft. The marked PC's **next die-modified roll's final number is announced by the Maiden** — pure foreshadowing of the turnabout. No mechanical penalty; it's dread.
+- **Role:** thematic; ties the warmup to the Crone reveal.
+
+### Back-Half Threats
+
+**The Unwoven (×1) — fate-proof brute** *(deploy when the party leans hard on the dice, or as a pacing valve)*
+A horror outside the tapestry. Reflavor **Flesh Golem** (or a Gloom for a leaner fight).
+- AC 9 (or 14 for golem), HP 93, Speed 30 ft.
+- **Fate-Immune:** no Fate Die may modify any d20 roll involving the Unwoven — attacks against it, its attacks, saves it forces. The crutch is gone.
+- Multiattack: 2× slam, +7, 2d8+4 bludgeoning.
+- *Berserk (golem):* below half HP, may rage.
+- **Role:** one honest fight; relieves the Hourglass pressure (no dice spent against it).
+
+**The Crone's Hand (×1) — climax, the turnabout made flesh**
+Appears when the Hourglass empties. Reflavor **a robed effigy of woven thread and bone** (use **Mage / Death Knight-lite** chassis, ~CR 5).
+- AC 15, HP 90, Speed 30 ft.
+- **She does not roll d20s.** Instead, on each of her actions she **takes the top numbered chunk off the Hourglass** and uses that number as her result — an attack roll, or as the save DC the party must beat (DC = the chunk number, capped sensibly), or as the Echo's attack. The party's cleverest spent saves become her blades.
+  - Example: a chunk reading "19" → her thread-lash hits AC 19; a chunk reading "4" → a weak swing that whiffs. *Greedy parties armed her with their best numbers.*
+- *Reclaim the Thread (1/turn):* pull a Restrained or marked PC 15 ft toward her.
+- **Optional — the Echo (×1):** a thread-spun copy of the PC who burned the most dice. Same AC, **half that PC's HP**, **one attack per turn using the top chunk off the Hourglass**. Unravels at 0 HP, **or** if its target spends a full turn refusing to fight it (the RP off-ramp).
+
+### MM2024 Block Mapping (build-from)
+Use these 2024 Monster Manual blocks as chassis; apply the listed tweaks. Total warmup is ~CR 7 across the trio + Spinners — appropriate for 3 level-5 PCs because the *real* threat (the Crone) is self-inflicted.
+
+| Encounter enemy | MM2024 block | Tweaks |
+|---|---|---|
+| **Spinner** (×3) | **Cultist** (CR 1/8) | Bump HP to 22; swap dagger for ranged spindle-sling (+4, 1d6+2, 30 ft); add the once-per-round *Drawing Thread* reroll. |
+| **Loom-Warden** | **Sea Hag** (CR 2) chassis | Drop to HP 75; replace Death Glare with *Shuttle Pass* (30 ft line, DC 14 Dex or Restrained, escape DC 14). Keep its melee as Skull-Weight (+5, 2d6+3, prone on DC 13 Str). |
+| **Measurer** | **Cult Fanatic** (CR 2) | Strip spellcasting down to flavor; add *Take the Measure* (mark, no penalty, foreshadow only). HP 40 as-is. |
+| **The Unwoven** | **Flesh Golem** (CR 5) | Use as-printed (Aversion to Fire, Berserk, Immutable Form). HP ~93–127. **House rule:** no Fate Die may modify any d20 involving it. |
+| **Crone's Hand** | **Green Hag** (CR 3) scaled up, *or* **Mage** (CR 6) toned down | Target AC 15 / HP 90. **Remove her d20 rolls entirely** — she uses Hourglass chunk numbers as her attack rolls / save DCs. Add *Reclaim the Thread* (pull 15 ft). |
+| **Echo** (optional) | mirror the burning-est PC | Same AC; HP = half that PC's max; one attack/turn using the top Hourglass chunk as its attack roll. |
+
+> If you'd rather not reskin a hag, the **Crone's Hand** also works as a custom CR 5: AC 15, HP 90, +6 to hit baseline (but *prefer the chunk number*), thread-lash 2d8+4. The "no d20s, spend chunks" rule is the only part that must stay.
+
+### Enemy Tactics
+- **Warmup:** Spinners screen; Loom-Warden restrains the party's anchor (likely [[torgana|Torgana]] or [[imwe|Imwe]]); Measurer marks the caster. Push hard enough that flipping a save feels worth it.
+- **Turn:** the moment the Hourglass empties, the Crone's Hand walks in from the Weaver's loom. Read her numbers aloud off the chunks — let the table realize whose luck just hit them.
+- **Endgame:** the Crone is only as strong as the chunks remaining. Burning/avoiding dice from here starves her.
+
+---
+
+## Round-by-Round Escalation
+- **R1–2:** Spinners + Loom-Warden engage. First die spent → Maiden giggles, panel unravels.
+- **R3–4:** Loom-Warden Shuttle Pass; Measurer marks. Hourglass approaches full.
+- **R5 (or when 6th chunk drops):** Hourglass empties → **Crone's Hand** + optional Echo enter. Announcer turn beat.
+- **R6+:** Crone spends chunks against the party. *(Optional:)* if dice were overused, the Unwoven crashes in here for a fate-proof brawl.
+- **Climax:** party must kill the Crone's Hand / unravel the Echo while **refusing to feed the Hourglass** — the win is starving her.
+
+### Victory Condition
+Drop the **Crone's Hand** (and unravel the Echo). The cleanest victory comes from **denying her chunks** — refusing dice at the critical moment.
+
+---
+
+## Objectives and Rewards
+
+### Primary Objective: Survive the Fates' game and drop the Crone's Hand.
+**Reward:** advancement, patron buzz ("they bested the gods' own dice"), and one **spent Fate Die** left on the sand as loot — a coveted, faintly cursed relic.
+
+### Secondary Objective: Empty the Hourglass via the crowd brake (claw back ≥2 chunks).
+**Reward:** +Favor and a weaker Crone.
+
+### Tertiary Objective: Refuse a Fate Die at a critical roll and survive anyway.
+**Reward:** +2 [[crowds_favor|Favor]] and a Fate's quiet respect — a future boon or debt (GM seeds in notes).
+
+---
+
+## Crowd Favor Opportunities
+- Spectacular Fate Die reversal (1 wrapped to 20, miss to crit): pull a chunk + [[crowds_favor|Favor]].
+- Refusing the die when it would obviously save you, and living: **+2 Favor**.
+- [[panache|Panache]] kill on a Spinner with a wrapped-around result: +1 Favor.
+- Destroying a Loom dramatically: Panache roll.
+- Killing the Crone's Hand on a turn where the party fed her **zero** new chunks: +2 Favor (defying the gods).
+
+---
+
+## Announcer Beats
+
+### Opening
+> "The card is BLANK — and yet the gods DESCEND! Three faces, one design, and GIFTS for our champions! Tell me, crowd — what could POSSIBLY go wrong?!"
+
+### Turn (Hourglass empties)
+> "The sand runs OUT! And the CRONE rises to collect her DEBT — with the very luck these fools SPENT! Their own brilliance, turned against them!"
+
+### Unwoven enters
+> "Behold — a thing the threads cannot TOUCH! No gift, no luck, no second chance saves you HERE!"
+
+### Victory
+> "They STARVED the gods of their own thread! The Crone's hand UNRAVELS! Fortune, dear crowd, favors the BOLD — and tonight, the DEFIANT!"
+
+---
+
+## GM Tips
+- **The chunks are everything.** Write the final number on each one as it's spent. They are the ledger, the Hourglass fill, *and* the Crone's ammunition. One object, three jobs.
+- Read the Crone's numbers **aloud off the chunks** — the dawning horror is the whole payoff.
+- Don't fudge the self-balancing math. A cautious party *earned* a weak Crone; a greedy one *armed* her.
+- Keep the Fates silent and serene — the Maiden's giggle on each spent die is your best recurring beat.
+- If the table forgets they can refuse the die, have [[Snak|Snak]]'s warning echo, or let the Weaver murmur "you needn't, you know" once.
+
+## Aftermath Seeds
+- The Crone offers a returning gladiator a "better die" next season — hook, trap, or both.
+- The spent Fate Die relic draws bids from shady seers; selling it may anger a Fate.
+- A PC who refused the die at the climax dreams of three faces; a future session can call in the boon/debt.
+
+---
+
+## Scaling Options
+
+### Too Easy?
+Hourglass empties at 5 chunks; Crone gains a 2nd action; add a 4th Spinner.
+
+### Too Hard?
+Hourglass empties at 7–8 chunks; Crone uses the *lowest* remaining chunk each turn; cut the Echo.
+
+### Too Little Chaos?
+Activate the Three Looms — thread-walls extend each round, carving the floor.
+
+### Too Much Chaos?
+Drop the Measurer and the optional Echo; run Spinners + Loom-Warden → Crone only.
+
+---
+
+## Victory Conditions
+- **Win:** Crone's Hand defeated (+ Echo unraveled).
+- **Clean Win:** the above with ≥2 chunks clawed back via crowd, or zero chunks fed in the final two rounds.
+- **Loss:** TPK, or the party arms the Crone so heavily (all-high chunks, no refusals) that she wipes them — a *self-inflicted* defeat the crowd will never forget.

--- a/sessions/session_10/session_10_fate_die_card.md
+++ b/sessions/session_10/session_10_fate_die_card.md
@@ -1,0 +1,41 @@
+---
+tags: [arena, session, player-handout, session-10]
+session_number: 10
+party_level: 5
+status: planned
+visibility: private
+created: 2026-05-20
+updated: 2026-05-20
+---
+
+# 🎲 The Fate Die — Player Card
+
+*A gift from the Three Fates. Use it well. They always take back what they lend.*
+
+---
+
+### How to use it
+**Reaction.** After you see the **raw result** of *any* d20 roll — yours, an ally's, or an enemy's (attack, save, check) — you may roll your **d8** and **add or subtract** it from that raw number. Decide add/subtract *after* you roll the d8.
+
+### The wrap (this is the gamble)
+- Go **over 20** → it wraps back to **0**, then keeps counting. *(19 + 5 = 24 → **4**)*
+- Go **under 1** → it wraps to **20**. *(3 − 5 = −2 → **18**)*
+
+A "safe" +3 on a 19 doesn't make 22 — it crashes to **2**.
+
+### The cost — read this twice
+Every number you end up with is **dropped into the Hourglass Heart.** The Crone is keeping count. When the sand runs out, she throws **your spent numbers back at you** as her own attacks and DCs. The luckier the save you steal, the deadlier the blade she returns.
+
+### What it does to the floor
+The ground where you stand when you use the die **unravels** — that 10 ft square becomes difficult terrain for the rest of the fight.
+
+---
+
+### Three ways to come out ahead
+1. **Make it spectacular.** A clutch save, a 1 wrapped into a 20, a miss turned to a crit — the crowd roars, you pull a chunk *back out* of the Hourglass, and you gain **Favor**.
+2. **Spend low, bank low.** The number you finish on is what she gets. Wrapping a 19 down to a 2 to barely succeed *also* hands her a useless 2.
+3. **Refuse.** At the worst moment, *don't* use it. Denying the Crone her ammunition is the way the cycle breaks — and the crowd loves nothing more than mortals defying the gods. **Big Favor.**
+
+---
+
+*One die per gladiator. One reaction per round. Choose your moments.*

--- a/sessions/session_10/session_10_notes.md
+++ b/sessions/session_10/session_10_notes.md
@@ -1,0 +1,131 @@
+---
+tags: [arena, session-notes, session-10]
+session_number: 10
+party_level: 5
+status: planned
+visibility: private
+created: 2026-05-20
+updated: 2026-05-20
+---
+
+# Session 10 Notes: The Weaver's Die
+
+## Pre-Session Summary
+**Party Playing:** (3 of)
+- [[imwe|Imwe]] —
+- [[torgana|Torgana]] —
+- [[father_crow|Father Crow]] —
+- [[killing_eagle_laughs|Killing Eagle Laughs]] —
+
+---
+
+## Session Objectives
+
+### Primary Goal
+Survive the Fates' game and defeat the Crone's Hand.
+
+### Secondary Goals
+- Claw back ≥2 chunks from the Hourglass via the crowd brake.
+- Refuse a Fate Die at a critical roll and survive.
+
+---
+
+## Key Mechanics
+
+### Fate Die Ledger (the Hourglass Heart)
+Record each die as it is spent. The final number is the Crone's ammunition.
+
+| # | PC | Raw d20 | d8 (±) | Final (banked) | Spent on (whose roll) | Clawed back? |
+|---|----|---------|--------|----------------|------------------------|--------------|
+| 1 | | | | | | |
+| 2 | | | | | | |
+| 3 | | | | | | |
+| 4 | | | | | | |
+| 5 | | | | | | |
+| 6 | | | | | | |
+
+**Hourglass empties at:** 6 chunks (3 PCs). Crone's Hand acts when emptied.
+
+### Tapestry Unravel Tracker
+Squares turned to difficult terrain (where dice were spent):
+
+### Status Tracker
+- Marked by Measurer:
+- Restrained by Loom-Warden:
+- Echo target (most dice burned):
+
+---
+
+## Crowd Favor Tracking
+
+| PC Name | Favor Earned | Favor Spent | Current Favor | Notable Actions |
+|---------|--------------|-------------|---------------|-----------------|
+| | | | | |
+| | | | | |
+| | | | | |
+
+### Favor Opportunities (Quick Reference)
+- Spectacular Fate Die reversal (claw back a chunk): +1
+- Refuse the die when it would save you, and live: +2
+- Panache kill on a Spinner with a wrapped result: +1
+- Destroy a Loom dramatically: Panache roll
+- Kill the Crone's Hand having fed her zero new chunks: +2
+
+---
+
+## Enemy Status
+| Enemy | HP | Status |
+|-------|----|--------|
+| Spinner 1 | 22 | |
+| Spinner 2 | 22 | |
+| Spinner 3 | 22 | |
+| Loom-Warden | 75 | |
+| Measurer | 40 | |
+| The Unwoven (if used) | 93 | |
+| Crone's Hand | 90 | |
+| Echo (if used) | half target HP | |
+
+---
+
+## Critical Moments Log
+
+---
+
+## Post-Session Summary
+
+### Outcome
+
+### PC Status After Session
+
+| PC Name | Status | Final Favor | Special Conditions | Level Up? |
+|---------|--------|-------------|-------------------|-----------|
+| | | | | |
+| | | | | |
+| | | | | |
+
+---
+
+## Rewards and Consequences
+
+### Loot Acquired
+- Spent Fate Die relic? (who holds it)
+
+### Ongoing Effects
+- Fate boon/debt owed to a PC who refused the die:
+
+---
+
+## Notes for Next Session
+
+### Plot Threads
+-
+
+### PC Development
+-
+
+### Arena Politics
+-
+
+### DM Reminders
+- Did greed or patience win? Note for callbacks.
+-

--- a/sessions/session_10/session_10_setup_gm.md
+++ b/sessions/session_10/session_10_setup_gm.md
@@ -1,0 +1,48 @@
+---
+tags: [arena, session, setup, session-10]
+session_number: 10
+party_level: 5
+status: planned
+visibility: private
+created: 2026-05-20
+updated: 2026-05-20
+---
+
+# Session 10 GM Setup: The Weaver's Die
+
+## Pre-Session Checklist
+
+**Party Composition:** 3 PCs, Level 5. Draw from the active roster — [[imwe|Imwe]] (Fighter), [[torgana|Torgana]] (Barbarian), [[father_crow|Father Crow]] (Cleric), [[killing_eagle_laughs|Killing Eagle Laughs]] (Ranger). Pick the 3 at the table.
+
+**Mechanics to Review:**
+- [[fate_die|Fate Die]] — read this cold before play; it's the spine of the session.
+- [[crowds_favor|Crowd's Favor]] and [[panache|Panache]] (the brake on the doom clock).
+
+**Key Resources / Table Prep:**
+- **3 physical d8s** to hand to players (one per Fate gift).
+- **6 "sand-chunk" tokens** for the Hourglass Heart (poker chips, scrap paper) + a marker to write spent numbers on them. A cleared pint glass / jar makes a fine visible Hourglass.
+- **A handful of terrain tokens** (10 ft squares) to drop where dice are spent — the unraveling Tapestry Floor.
+- A separate mini for the **Crone's Hand** and one for the optional **Echo**.
+
+**Session Goal:** Teach the Fate Die through a survivable warmup, let greed fill the Hourglass, then turn the party's own spent luck against them. The emotional target: a player *refusing* to spend a die at the climax to break the cycle.
+
+---
+
+## How the Session Breathes (pacing)
+1. **Gift scene (RP):** the Three Fates appear, one face at three ages. Each presses a d8 into one PC's hand. State the rule out loud, including *"we always take back what we lend."* Informed consent makes the betrayal land.
+2. **Warmup — Spinners + Loom-Warden + Measurer:** survivable, but the Loom-Warden's restraint saves should *beg* to be flipped with a die. Goal: get 4–6 dice spent and the Hourglass nearly full.
+3. **The turn:** when the Hourglass empties, the Crone steps in and replays the banked numbers. Telegraph it — she's been knitting at the edge the whole time.
+4. **The Unwoven (optional valve):** if players are spamming dice or the table needs a clean fight, the Crone snips a thread and the fate-proof Unwoven enters.
+5. **The Choice:** to end it, someone refuses a die at a critical roll (or burns a banked Favor advantage), denying the Crone ammunition.
+
+## Balancing Notes
+- The encounter is **self-balancing**: cautious parties fill the Hourglass slowly and face a weak Crone; greedy parties arm her. Lean into that — don't fudge.
+- If nobody is spending dice (too cautious), the Loom-Warden should press harder: stack restraints, threaten a downed PC.
+- If the Hourglass fills too fast and a TPK looms, the Unwoven is your pressure-*relief* (no dice, but a straightforward fight) — and the crowd brake lets them claw chunks back.
+
+---
+
+## Roleplaying Hooks
+- **The Three Fates** never raise their voices. The Maiden giggles when a die is spent. The Weaver narrates outcomes a beat before they happen. The Crone only speaks to collect.
+- A PC who **refuses** the die at the climax earns a Fate's quiet respect — seed a future boon (or a future debt) in [[session_10_notes|notes]].
+- [[Snak|Snak]] is uneasy about gods on his sand; he warned them not to take gifts from strangers. He'll say "I told you so" if it goes badly.

--- a/sessions/session_10/session_10_setup_players.md
+++ b/sessions/session_10/session_10_setup_players.md
@@ -1,0 +1,30 @@
+---
+tags: [arena, session, setup, session-10]
+session_number: 10
+party_level: 5
+status: planned
+visibility: private
+created: 2026-05-20
+updated: 2026-05-20
+---
+
+# Session 10 Setup: The Weaver's Die
+
+### 3 Days Before the Match
+Word from the last bout still hangs over the pens — the crowd remembers, and so do the patrons. But something stranger has the bookmakers spooked: three different visitors, all asking after *you* by name, all wearing (the stable hands swear) the same pale, horned face.
+
+### The Night Before the Match
+[[Snak|Snak]] comes into the pen, and for once he isn't selling anything. He's nervous.
+
+"Listen close. There's no beast on the card tomorrow. No champion. The bout's been *bought* — by someone who didn't pay in coin." He scratches at his neck. "Three women came to the office. Same face, near as anyone can tell. A girl, a grown one, and an old crone. They want to give you *presents.*"
+
+He leans in. "Take advice from a creature that's survived this place: **nothing on this sand is free.** If you're offered a gift, you'd best understand the price before you close your hand on it."
+
+*(If they've paid for Snak's intel:)* "Here's what I scraped together. The floor's been re-laid — woven, like a rug, with pictures in it. Don't look too long at the one with your face. And there's an hourglass going up at center stage, big as a man. The more you lot... *cheat*, the faster it runs. That's all I got. Whatever they're playing at, the rules favor patience over greed."
+
+### An Hour Before the Match
+No special attunements tonight. But each of you will be handed something on the sand — that's part of the show. You decide whether to use it.
+
+### As You Walk Into the Arena
+
+> "GLADIATORS! Tonight the card is BLANK — and yet the stands are FULL! For tonight, honored friends, the GODS THEMSELVES descend to play! Three faces, three ages, ONE design! They come bearing GIFTS, dear crowd — and what, I ask you, could possibly GO WRONG?!"


### PR DESCRIPTION
## Summary
A new Fate-themed session built around a self-balancing twist: players are gifted a **Fate Die** that lets them cheat any d20, but every value they spend is banked and replayed against them by the Crone. The real difficulty is whatever luck the party hands her — greed arms the boss, patience starves it.

## What's here
- **`ideas/the_weavers_die.md`** — the concept (Three Fates, Tapestry Floor, Hourglass Heart, spin/weave/measure enemy trio, the fate-proof Unwoven, the Crone's Hand, the "refuse the die" climax).
- **`mechanics/fate_die.md`** — the d8 reaction die: add/subtract from any raw d20, wrap over-20→0 and under-1→20, spent values banked in the Hourglass and used back against the party.
- **`sessions/session_10/`** — full session for **3 level-5 PCs**:
  - GM setup, player briefing, detailed encounter (with MM2024 block mappings), notes template, a player-facing Fate Die card, index + `.pages`.

## Design notes
- The **sand chunks are the only ledger** — they serve as Hourglass fill, terrain trigger, and the Crone's ammunition at once.
- Encounter is **self-balancing**; warmup is ~CR 7 (merely *hard*) on purpose — the lethality is self-inflicted.
- All new files are `visibility: private` and intentionally **not** linked from the public `sessions/index.md` / `mechanics/index.md` until marked ready.

Stray `Untitled*.md` files in the working tree were left untouched.